### PR TITLE
tests: add fixture for `use` include statements

### DIFF
--- a/tests/Compiler/Fixture/BladeToPHPCompiler/basic_include_with_use_statements.blade.php
+++ b/tests/Compiler/Fixture/BladeToPHPCompiler/basic_include_with_use_statements.blade.php
@@ -1,0 +1,2 @@
+@include('include_with_use_statements')
+-----

--- a/tests/Compiler/Fixture/BladeToPHPCompiler/include_with_use_statements.blade.php
+++ b/tests/Compiler/Fixture/BladeToPHPCompiler/include_with_use_statements.blade.php
@@ -1,0 +1,14 @@
+@php
+use Illuminate\Support\Facades\URL;
+
+URL::current();
+@endphp
+-----
+<?php
+
+/** file: foo.blade.php, line: 1 */
+/** file: foo.blade.php, line: 2 */
+use Illuminate\Support\Facades\URL;
+/** file: foo.blade.php, line: 4 */
+URL::current();
+/** file: foo.blade.php, line: 5 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When using the `@include()` directive with a file that contains `use` statements, in Blade it compiles to separate files, whereas AFAICT this package compiles to a single file which is checked (correct me if I'm wrong). But this causes the `use` statements to fail as they are in the global scope. Resulting in a PHP syntax error.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/.github/blob/main/CONTRIBUTING.md)** document.
